### PR TITLE
Add chronological archive page

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -1,3 +1,6 @@
+---
+title: Archive
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,7 +19,13 @@
         </nav>
         <main id="content">
             <h1>Archive</h1>
-            <p>This page will list all my posts.</p>
+            <ul>
+                {% for post in site.posts reversed %}
+                <li>
+                    <a href="{{ post.url }}">{{ post.title }}</a> - {{ post.date | date: "%Y-%m-%d" }}
+                </li>
+                {% endfor %}
+            </ul>
         </main>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- add Jekyll front matter to archive page
- list all posts in chronological order using `site.posts reversed`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dec45c2cc832a9ebfd74882b07f37